### PR TITLE
Fix Dotenv from dev dependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "knex": "^0.19.1",
     "npm-run-all": "^4.1.5",
     "pg": "^7.12.0",
-    "slack": "^11.0.2"
+    "slack": "^11.0.2",
+    "dotenv": "^8.1.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.5",
     "cross-env": "^5.2.0",
-    "dotenv": "^8.1.0",
     "eslint": "^6.2.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
FIX: Moves package DotEnv from dev dependency to dependency. 