### PR TITLE
Fix: remove view button in shoutout notification

### DIFF
--- a/data/slackComponents/attachments.js
+++ b/data/slackComponents/attachments.js
@@ -57,10 +57,19 @@ exports.errorALert = text => {
 
 exports.channelNotification = (data, type = null) => {
   let color;
+  let actions;
   if (type === 'view') {
     color = '#A9A9A9';
+    actions = [
+      {
+        type: 'button',
+        text: 'View',
+        url: `${data.clientUrl}/shoutout/${data.id}`,
+      },
+    ];
   } else {
     color = '#4265ED';
+    actions = [];
   }
   const attachment = JSON.stringify([
     {
@@ -69,13 +78,7 @@ exports.channelNotification = (data, type = null) => {
       title: 'Shoutout:',
       text: `${data.content}`,
       color: color,
-      actions: [
-        {
-          type: 'button',
-          text: 'View',
-          url: `${data.clientUrl}/shoutout/${data.id}`,
-        },
-      ],
+      actions: actions,
       footer: data.footer,
     },
   ]);


### PR DESCRIPTION
# Description

**Motivation**
- when a shoutout is given and bot posts message in the channel, there is a view button which allows users to see the single shoutout in the webapp, which doesn't follow design

**Finish Line**
- view button is removed from public shoutout bot message and is displayed only on the view shoutouts command

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe steps taken to ensure this feature is functional and does not break other features:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [x] I have run the app using my feature and ensured that no functionality is broken
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
